### PR TITLE
A little fix for slim symbols substitution

### DIFF
--- a/slim.ps1
+++ b/slim.ps1
@@ -340,7 +340,7 @@ function Set-Script($s, $fmt){
   {
 	$s = $s -replace '</?pre>' #workaround fitnesse strange behavior
   }
-  if($slimsymbols.Count){$slimsymbols.Keys | ? {!($s -cmatch "\`$$_\s*=")} | ? {$slimsymbols[$_] -is [string] } | % {$s=$s -creplace "\`$$_",$slimsymbols[$_] }}
+  if($slimsymbols.Count){$slimsymbols.Keys | ? {!($s -cmatch "\`$$_\s*=")} | ? {$slimsymbols[$_] -is [string] } | % {$s=$s -creplace "\`$$_\b",$slimsymbols[$_] }}
   if($slimsymbols.Count){$slimsymbols.Keys | % { Set-Variable -Name $_ -Value $slimsymbols[$_] -Scope Global}}
   $s = [string]::Format( $fmt, $s)
   if($s.StartsWith('function',$true,$null)){Set-Variable -Name Script__ -Value ($s -replace 'function\s+(.+)(?=\()','function script:$1') -Scope Global}


### PR DESCRIPTION
Added word boundary in replace statement matcher in order to avoid partial variable substitution.
For example if you have two variables named $VAR_1 and $VAR_12 there's a chance that only part of the actual variable name **$VAR_1**2 will be matched.