### PR TITLE
Added timestamps to PowerSlim output

### DIFF
--- a/FitNesseRoot/PowerSlim/SuiteREST/TestGET/content.txt
+++ b/FitNesseRoot/PowerSlim/SuiteREST/TestGET/content.txt
@@ -16,3 +16,4 @@
 |maxbeard12/PowerSlim|
 |mikeplavsky/PowerSlim|
 |testdemo1001/PowerSlim|
+|DmitryKonev/PowerSlim|

--- a/slim.ps1
+++ b/slim.ps1
@@ -450,7 +450,7 @@ function Invoke-SlimInstruction(){
     # the execution of the 'make' procedure.
     $result = Invoke-SlimCall $ins[3]
   }
-  (Get-Date -f "dd.MM.yy HH:mm:ss.fff") + "`t" + $Script__ + " : " + $script:Command_Time.TotalSeconds | Out-Default
+  Write-Log $Script__ : $script:Command_Time.TotalSeconds
 
   if($symbol){$slimsymbols[$symbol] = $result}
   
@@ -614,17 +614,22 @@ function Run-SlimServer($ps_server){
 }
 
 function Run-RemoteServer($ps_server){
-  (Get-Date -f "dd.MM.yy HH:mm:ss.fff") + "`t" + "waiting..." | Out-Default
+  Write-Log "waiting..."
   while($ps_fitnesse_client = $ps_server.AcceptTcpClient()){
-    (Get-Date -f "dd.MM.yy HH:mm:ss.fff") + "`t" + "accepted!" | Out-Default
+    Write-Log "accepted!"
     $ps_fitnesse_stream = $ps_fitnesse_client.GetStream()
     $ps_fitnesse_stream.ReadTimeout = $REQUEST_READ_TIMEOUT
     
     process_message_ignore_remote($ps_fitnesse_stream)
     $ps_fitnesse_stream.Close()
     $ps_fitnesse_client.Close()
-    (Get-Date -f "dd.MM.yy HH:mm:ss.fff") + "`t" + "waiting..." | Out-Default
+    Write-Log "waiting..."
   }
+}
+
+function Write-Log (){
+  $timestamp = Get-Date -f "dd.MM.yy HH:mm:ss.fff"
+  Write-Host $timestamp"`t"$args
 }
 
 # if (!$args.Length) { 
@@ -632,7 +637,7 @@ function Run-RemoteServer($ps_server){
   # return; 
 # }
 
-(Get-Date -f "dd.MM.yy HH:mm:ss.fff") + "`t" + "========== Starting SLIM $Mode on Port $Port ==========" |Out-Default
+Write-Log "========== Starting SLIM $Mode on Port $Port =========="
 
 $ps_server = New-Object System.Net.Sockets.TcpListener($Port)
 $ps_server.Start()

--- a/slim.ps1
+++ b/slim.ps1
@@ -450,7 +450,7 @@ function Invoke-SlimInstruction(){
     # the execution of the 'make' procedure.
     $result = Invoke-SlimCall $ins[3]
   }
-  $Script__ + " : " + $script:Command_Time.TotalSeconds | Out-Default
+  (Get-Date -f "dd.MM.yy HH:mm:ss.fff") + "`t" + $Script__ + " : " + $script:Command_Time.TotalSeconds | Out-Default
 
   if($symbol){$slimsymbols[$symbol] = $result}
   
@@ -614,16 +614,16 @@ function Run-SlimServer($ps_server){
 }
 
 function Run-RemoteServer($ps_server){
-  "waiting..." | Out-Default
+  (Get-Date -f "dd.MM.yy HH:mm:ss.fff") + "`t" + "waiting..." | Out-Default
   while($ps_fitnesse_client = $ps_server.AcceptTcpClient()){
-    "accepted!" | Out-Default
+    (Get-Date -f "dd.MM.yy HH:mm:ss.fff") + "`t" + "accepted!" | Out-Default
     $ps_fitnesse_stream = $ps_fitnesse_client.GetStream()
     $ps_fitnesse_stream.ReadTimeout = $REQUEST_READ_TIMEOUT
     
     process_message_ignore_remote($ps_fitnesse_stream)
     $ps_fitnesse_stream.Close()
     $ps_fitnesse_client.Close()
-    "waiting..." | Out-Default
+    (Get-Date -f "dd.MM.yy HH:mm:ss.fff") + "`t" + "waiting..." | Out-Default
   }
 }
 
@@ -632,7 +632,7 @@ function Run-RemoteServer($ps_server){
   # return; 
 # }
 
-"Starting SLIM $Mode on Port $Port" |Out-Default
+(Get-Date -f "dd.MM.yy HH:mm:ss.fff") + "`t" + "========== Starting SLIM $Mode on Port $Port ==========" |Out-Default
 
 $ps_server = New-Object System.Net.Sockets.TcpListener($Port)
 $ps_server.Start()


### PR DESCRIPTION
This improvement is quite useful in case Output is redirected to a file for further debug and log analysis purposes.
TestGET is also fixed after new fork creation.