### PR TITLE
fix symbol replacement again

### DIFF
--- a/FitNesseRoot/PowerSlim/OriginalMode/SuiteSymbols/TestIssueSymbolSubstitution/content.txt
+++ b/FitNesseRoot/PowerSlim/OriginalMode/SuiteSymbols/TestIssueSymbolSubstitution/content.txt
@@ -1,0 +1,9 @@
+'''https://github.com/konstantinvlasenko/PowerSlim/pull/82'''
+
+|script                       |
+|$SymbolPrefix = |eval|"test1"|
+|$SymbolPrefix1 =|eval|"test2"|
+
+|script                                     |
+|check|eval|"$SymbolPrefix_test" |test1_test|
+|check|eval|"$SymbolPrefix1_test"|test2_test|

--- a/FitNesseRoot/PowerSlim/OriginalMode/SuiteSymbols/TestIssueSymbolSubstitution/properties.xml
+++ b/FitNesseRoot/PowerSlim/OriginalMode/SuiteSymbols/TestIssueSymbolSubstitution/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/slim.ps1
+++ b/slim.ps1
@@ -332,7 +332,7 @@ function Set-Script($s, $fmt){
   {
 	$s = $s -replace '</?pre>' #workaround fitnesse strange behavior
   }
-  if($slimsymbols.Count){$slimsymbols.Keys | ? {!($s -cmatch "\`$$_\s*=")} | ? {$slimsymbols[$_] -is [string] } | % {$s=$s -creplace "\`$$_\b",$slimsymbols[$_] }}
+  if($slimsymbols.Count){$slimsymbols.Keys | Sort Length -Descending | ? {!($s -cmatch "\`$$_\s*=")} | ? {$slimsymbols[$_] -is [string] } | % {$s=$s -creplace "\`$$_",$slimsymbols[$_] }}
   if($slimsymbols.Count){$slimsymbols.Keys | % { Set-Variable -Name $_ -Value $slimsymbols[$_] -Scope Global}}
   $s = $fmt -f $s
   if($s.StartsWith('function',$true,$null)){Set-Variable -Name Script__ -Value ($s -replace 'function\s+(.+)(?=\()','function script:$1') -Scope Global}


### PR DESCRIPTION
My previous fix for this was not accurate: #66 
It incorrectly handled situations, in which symbol instantiation is not terminated with a word boundary. The general symbol instantiation behavior, which Fitnesse actually expects from the slim protocol implementors, is that it should substitute the maximum length occurrence of symbol in command. And symbol does not necessarily have to be terminated with a word boundary.
For example, say, if we have two symbols $mbxPrefix, $mbxPrefix2 and a script:
`$mbxPrefix2_1`, then the symbol $mbxPrefix2 should be chosen and replaced, and not $mbxPrefix.