### PR TITLE
add red test case for symbol sharing issue#83

### DIFF
--- a/FitNesseRoot/PowerSlim/OriginalMode/SuiteRemoting/SymbolSharing/TestRemoteObjectSymbol/content.txt
+++ b/FitNesseRoot/PowerSlim/OriginalMode/SuiteRemoting/SymbolSharing/TestRemoteObjectSymbol/content.txt
@@ -1,0 +1,38 @@
+!define REMOTE_SERVER {localhost:35}
+
+
+
+
+!|script|Remote|${REMOTE_SERVER}|
+|eval|!-<pre>function GetRemoteComputerCommands()
+{
+    $ret = New-Object -TypeName PSObject -Property @{
+            "Success" = $false
+            "Name" = $null
+            "CommandType"  = $null
+            "ModuleName" = $null
+    }
+    try{
+        $cmds = Get-Command *Computer
+    }
+    catch{
+        return $ret
+    }
+    $ret.Success     = $true
+    $ret.Name        = $cmds.Name
+    $ret.CommandType = $cmds.CommandType
+    $ret.ModuleName  = $cmds.ModuleName
+    return $ret
+}
+</pre>-!|
+|$computerCmds=|eval|GetRemoteComputerCommands|
+|check|eval|$computerCmds.Success|True|
+|$commandNames=|eval|$computerCmds.Name|
+
+
+
+!|script|Remote|${REMOTE_SERVER}|
+|$whereIsMyCommandNames=|eval|$computerCmds.Name|
+|check|eval||$whereIsMyCommandNames|$commandNames|
+
+

--- a/FitNesseRoot/PowerSlim/OriginalMode/SuiteRemoting/SymbolSharing/TestRemoteObjectSymbol/properties.xml
+++ b/FitNesseRoot/PowerSlim/OriginalMode/SuiteRemoting/SymbolSharing/TestRemoteObjectSymbol/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>


### PR DESCRIPTION
https://github.com/konstantinvlasenko/PowerSlim/issues/83

When a remote table get PS-Object from remote, it's not shared by other remote table.
This is the RED test case for the issue #83 
