### PR TITLE
Don't skip all remaining tests if WebException caught

### DIFF
--- a/slim.ps1
+++ b/slim.ps1
@@ -630,6 +630,7 @@ function process_message($ps_stream){
 function process_message_ignore_remote($ps_stream){
 
   Write-Verbose "Process Message & Ignore Remote"
+  $script:SLIM_ABORT_TEST = $false
 
   $ps_msg = get_message($ps_stream)
 


### PR DESCRIPTION
I've found an issue that if WebException handled by powerslim script on remote server, all remaining tests are skipped.
This happened because $script:SLIM_ABORT_TEST set to true if System.Net.WebException caught. (function Exec-Script) and never reset for remote server. This flag is reset in function process_message called from Run-SlimServer, but is not reset when callstack root is Run-RemoteServer.  As a result, all tests after failed test skipped with message ABORT_TEST_INDICATED:Test not run.